### PR TITLE
[refactor & feat] Signup API 추가

### DIFF
--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/config/authentication/AuthenticationFilter.java
@@ -29,7 +29,7 @@ public class AuthenticationFilter extends HttpFilter {
 
         String requestURI = request.getRequestURI();
 
-        if (shouldBypass(requestURI)) {
+        if (isBypassAvailable(requestURI)) {
             chain.doFilter(request, response);
             return;
         }
@@ -48,7 +48,7 @@ public class AuthenticationFilter extends HttpFilter {
         }
     }
 
-    private boolean shouldBypass(String requestURI) {
+    private boolean isBypassAvailable(String requestURI) {
         return requestURI.startsWith("/h2-console") || requestURI.startsWith("/health");
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/MemberController.java
@@ -1,6 +1,6 @@
 package com.startingblue.fourtooncookie.member;
 
-import com.startingblue.fourtooncookie.member.dto.request.MemberUpdateRequest;
+import com.startingblue.fourtooncookie.member.dto.request.MemberSaveRequest;
 import com.startingblue.fourtooncookie.member.dto.response.MemberSavedResponse;
 import com.startingblue.fourtooncookie.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +22,10 @@ public final class MemberController {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/member")
-    public ResponseEntity<HttpStatus> updateMember(UUID memberId, @RequestBody MemberUpdateRequest memberUpdateRequest) {
-        memberService.updateById(memberId, memberUpdateRequest);
-        return ResponseEntity
-                .noContent()
-                .build();
+    @PostMapping("/member")
+    public ResponseEntity<HttpStatus> saveMember(UUID memberId, @RequestBody MemberSaveRequest memberSaveRequest) {
+        memberService.save(memberId, memberSaveRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping("/member")

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
@@ -22,7 +22,6 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private UUID id;
 
-    @NotNull
     @Column(name = "email")
     private String email;
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.startingblue.fourtooncookie.member.domain;
 
+import com.startingblue.fourtooncookie.config.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -15,10 +16,9 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "member_id")
     private UUID id;
 
@@ -41,7 +41,7 @@ public class Member {
     private Role role;
 
     @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    private LocalDateTime deletedDateTime;
 
     public void update(String name, LocalDate birth, Gender gender) {
         this.name = name;
@@ -56,10 +56,10 @@ public class Member {
         if (current.isAfter(LocalDateTime.now())) {
             throw new IllegalArgumentException("Current time cannot be after current time");
         }
-        if (deletedAt != null && current.isAfter(deletedAt)) {
+        if (deletedDateTime != null && current.isAfter(deletedDateTime)) {
             throw new IllegalArgumentException("Cannot delete at a time after the current deletedAt timestamp");
         }
-        deletedAt = current;
+        deletedDateTime = current;
     }
 
     public boolean isAdmin() {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
@@ -40,7 +40,7 @@ public class Member extends BaseEntity {
     @Column(name = "role")
     private Role role;
 
-    @Column(name = "deleted_at")
+    @Column(name = "deleted_date_time")
     private LocalDateTime deletedDateTime;
 
     public void update(String name, LocalDate birth, Gender gender) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/domain/Member.java
@@ -26,12 +26,15 @@ public class Member extends BaseEntity {
     @Column(name = "email")
     private String email;
 
+    @NotNull
     @Column(name = "name")
     private String name;
 
+    @NotNull
     @Column(name = "birth")
     private LocalDate birth;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
     @Column(name = "gender")
     private Gender gender;

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/dto/request/MemberSaveRequest.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/dto/request/MemberSaveRequest.java
@@ -4,5 +4,5 @@ import com.startingblue.fourtooncookie.member.domain.Gender;
 
 import java.time.LocalDate;
 
-public record MemberSaveRequest(String email, String name, LocalDate birth, Gender gender) {
+public record MemberSaveRequest(String name, LocalDate birth, Gender gender) {
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/dto/request/MemberSaveRequest.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/dto/request/MemberSaveRequest.java
@@ -4,5 +4,5 @@ import com.startingblue.fourtooncookie.member.domain.Gender;
 
 import java.time.LocalDate;
 
-public record MemberUpdateRequest(String name, LocalDate birth, Gender gender) {
+public record MemberSaveRequest(String email, String name, LocalDate birth, Gender gender) {
 }

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/exception/MemberExceptionControllerAdvice.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/exception/MemberExceptionControllerAdvice.java
@@ -12,10 +12,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class MemberExceptionControllerAdvice {
 
-    @ExceptionHandler(EntityNotFoundException.class)
+    @ExceptionHandler({EntityNotFoundException.class, MemberNotFoundException.class})
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public String handleEntityNotFoundExceptionException(EntityNotFoundException e) {
-        log.error(e.getMessage(), e);
+    public String handleNotFoundExceptions(RuntimeException e) {
+        log.error("Error occurred: {}", e.getMessage(), e);
         return "Member Not Found";
     }
 

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
@@ -32,7 +32,7 @@ public class MemberService {
     }
 
     public Member readById(final UUID memberId) {
-        return  memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("member not found"));
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("member not found"));
     }
 
     public void softDeleteById(UUID memberId) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
@@ -2,7 +2,8 @@ package com.startingblue.fourtooncookie.member.service;
 
 import com.startingblue.fourtooncookie.member.domain.Member;
 import com.startingblue.fourtooncookie.member.domain.MemberRepository;
-import com.startingblue.fourtooncookie.member.dto.request.MemberUpdateRequest;
+import com.startingblue.fourtooncookie.member.domain.Role;
+import com.startingblue.fourtooncookie.member.dto.request.MemberSaveRequest;
 import com.startingblue.fourtooncookie.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,18 +19,20 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public void save(Member member) {
+    public void save(final UUID memberId, final MemberSaveRequest memberSaveRequest) {
+        Member member = Member.builder()
+                .id(memberId)
+                .email(memberSaveRequest.email())
+                .name(memberSaveRequest.name())
+                .birth(memberSaveRequest.birth())
+                .gender(memberSaveRequest.gender())
+                .role(Role.MEMBER)
+                .build();
         memberRepository.save(member);
     }
 
-    public Member readById(UUID memberId) {
+    public Member readById(final UUID memberId) {
         return  memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException("member not found"));
-    }
-
-    public void updateById(final UUID memberId, final MemberUpdateRequest memberUpdateRequest) {
-        Member member = readById(memberId);
-        member.update(memberUpdateRequest.name(), memberUpdateRequest.birth(), memberUpdateRequest.gender());
-        memberRepository.save(member);
     }
 
     public void softDeleteById(UUID memberId) {

--- a/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
+++ b/fourtooncookie/src/main/java/com/startingblue/fourtooncookie/member/service/MemberService.java
@@ -22,7 +22,6 @@ public class MemberService {
     public void save(final UUID memberId, final MemberSaveRequest memberSaveRequest) {
         Member member = Member.builder()
                 .id(memberId)
-                .email(memberSaveRequest.email())
                 .name(memberSaveRequest.name())
                 .birth(memberSaveRequest.birth())
                 .gender(memberSaveRequest.gender())

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/domain/DiaryRepositoryTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/domain/DiaryRepositoryTest.java
@@ -174,6 +174,7 @@ class DiaryRepositoryTest {
 
     private Member createMember() {
         Member member = Member.builder()
+                .id(UUID.randomUUID())
                 .name("testUser")
                 .email("test@email.com")
                 .birth(LocalDate.of(2024, 7, 23))

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/domain/DiaryTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/domain/DiaryTest.java
@@ -55,6 +55,7 @@ public class DiaryTest {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 
         member = Member.builder()
+                .id(UUID.randomUUID())
                 .name("John Doe")
                 .birth(LocalDate.of(1990, 1, 1))
                 .email("john.doe@example.com")

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/diary/service/DiaryServiceTest.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -229,6 +230,7 @@ class DiaryServiceTest {
 
     private Member createMember(String name, LocalDate birthDate, Gender gender) {
         return Member.builder()
+                .id(UUID.randomUUID())
                 .name(name)
                 .birth(birthDate)
                 .email("temp@gmail.com")

--- a/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/member/service/MemberServiceTest.java
+++ b/fourtooncookie/src/test/java/com/startingblue/fourtooncookie/member/service/MemberServiceTest.java
@@ -4,7 +4,6 @@ import com.startingblue.fourtooncookie.member.domain.Gender;
 import com.startingblue.fourtooncookie.member.domain.Member;
 import com.startingblue.fourtooncookie.member.domain.MemberRepository;
 import com.startingblue.fourtooncookie.member.dto.response.MemberSavedResponse;
-import com.startingblue.fourtooncookie.member.dto.request.MemberUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -62,44 +61,7 @@ public class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("supabase에 있는 멤버 정보를 수정한다.")
-    void updateById() {
-        UUID memberId = UUID.randomUUID();
-        String oldEmail = "oldemail@example.com";
-        String oldName = "Old Name";
-        LocalDate oldBirth = LocalDate.of(1990, 1, 1);
-        Gender oldGender = Gender.MALE;
-
-        Member member = Member.builder()
-                .id(memberId)
-                .email(oldEmail)
-                .name(oldName)
-                .birth(oldBirth)
-                .gender(oldGender)
-                .build();
-
-        String newName = "New Name";
-        LocalDate newBirth = LocalDate.of(1991, 2, 2);
-        Gender newGender = Gender.FEMALE;
-
-        // when
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(memberRepository.save(member)).thenReturn(member);
-
-        MemberUpdateRequest updateRequest = new MemberUpdateRequest(newName, newBirth, newGender);
-        memberService.updateById(memberId, updateRequest);
-        Member updatedMember = memberRepository.findById(memberId).orElse(null);
-
-        // then
-        assertThat(updatedMember).isNotNull();
-        assertThat(updatedMember.getEmail()).isEqualTo(oldEmail); // Email is not updated in the updateById method
-        assertThat(updatedMember.getName()).isEqualTo(newName);
-        assertThat(updatedMember.getBirth()).isEqualTo(newBirth);
-        assertThat(updatedMember.getGender()).isEqualTo(newGender);
-    }
-
-    @Test
-    @DisplayName("supabase에 저장된 멤버를 소프트 삭제 한다. deleteAt을 갱신 한다.")
+    @DisplayName("저장된 멤버를 소프트 삭제 한다. deleteAt을 갱신 한다.")
     void softDeleteByIdById() {
         UUID memberId = UUID.randomUUID();
         String email = "test@example.com";
@@ -122,7 +84,7 @@ public class MemberServiceTest {
 
         Member deletedMember = memberRepository.findById(memberId).orElse(null);
         assertThat(deletedMember).isNotNull();
-        assertThat(deletedMember.getDeletedAt()).isEqualTo(current);
+        assertThat(deletedMember.getDeletedDateTime()).isEqualTo(current);
     }
 
     @Test
@@ -175,7 +137,7 @@ public class MemberServiceTest {
 
         Member deletedMember = memberRepository.findById(memberId).orElse(null);
         assertThat(deletedMember).isNotNull();
-        assertThat(deletedMember.getDeletedAt()).isEqualTo(past);
+        assertThat(deletedMember.getDeletedDateTime()).isEqualTo(past);
     }
 
     @Test


### PR DESCRIPTION
# [refactor & feat] Signup API 추가
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [x] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-271
---
* 구현 내용
- [PATCH]updateMember -> [POST]saveMember 로 변경
- 멤버 회원가입 요청 인 경우 handleSignup()
    회원가입 하려는 멤버(JWT sub)가 DB member_id 컬럼에 존재하지 않으면 회원가입 가능 (중복 회원가입 방지)
- 이외의 경우는 handleLogin()
